### PR TITLE
enabling clang_tidy, pylint and build_check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,50 @@
+---
+Checks:          '-*,
+                  performance-*,
+                  llvm-namespace-comment,
+                  modernize-redundant-void-arg,
+                  modernize-use-nullptr,
+                  modernize-use-default,
+                  modernize-use-override,
+                  modernize-loop-convert,
+                  readability-named-parameter,
+                  readability-redundant-smartptr-get,
+                  readability-redundant-string-cstr,
+                  readability-simplify-boolean-expr,
+                  readability-container-size-empty,
+                  readability-identifier-naming,
+                  '
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+CheckOptions:
+  - key:             llvm-namespace-comment.ShortNamespaceLines
+    value:           '10'
+  - key:             llvm-namespace-comment.SpacesBeforeComments
+    value:           '2'
+  - key:             readability-braces-around-statements.ShortStatementLines
+    value:           '2'
+  # type names
+  - key:             readability-identifier-naming.ClassCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.EnumCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.UnionCase
+    value:           CamelCase
+  # method names
+  - key:             readability-identifier-naming.MethodCase
+    value:           camelBack
+  # variable names
+  - key:             readability-identifier-naming.VariableCase
+    value:           lower_case
+  - key:             readability-identifier-naming.ClassMemberSuffix
+    value:           '_'
+  # const static or global variables are UPPER_CASE
+  - key:             readability-identifier-naming.EnumConstantCase
+    value:           UPPER_CASE
+  - key:             readability-identifier-naming.StaticConstantCase
+    value:           UPPER_CASE
+  - key:             readability-identifier-naming.ClassConstantCase
+    value:           UPPER_CASE
+  - key:             readability-identifier-naming.GlobalVariableCase
+    value:           UPPER_CASE
+...

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
         env:
           ROS_DISTRO: humble # Replace humble for your chosen distro.
           # UPSTREAM_WORKSPACE: dependencies.rosinstall
-          # BEFORE_BUILD_TARGET_WORKSPACE: 'apt update -q && python3 -m pip install ****'
+          BEFORE_BUILD_TARGET_WORKSPACE: 'apt update -q && apt install -y python3-tk && python3 -m pip install pillow numpy numpy-quaternion ruamel.yaml'
           PYLINT_ARGS: '--errors-only'
           PYLINT_CHECK: true
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,19 +18,19 @@ jobs:
           CLANG_FORMAT_CHECK: file
           CLANG_FORMAT_VERSION: "14"
 
-  # clang_tidy_check:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: checkout
-  #       uses: actions/checkout@v2
-  #     - name: run industrial_ci
-  #       uses: 'ros-industrial/industrial_ci@master'
-  #       env:
-  #         ROS_DISTRO: humble # Replace humble for your chosen distro.
-  #         # UPSTREAM_WORKSPACE: dependencies.rosinstall
-  #         # BEFORE_BUILD_TARGET_WORKSPACE: 'apt update -q && python3 -m pip install ****'
-  #         CLANG_TIDY_ARGS: '--extra-arg=-std=c++17'
-  #         CLANG_TIDY: pedantic
+  clang_tidy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: run industrial_ci
+        uses: 'ros-industrial/industrial_ci@master'
+        env:
+          ROS_DISTRO: humble # Replace humble for your chosen distro.
+          # UPSTREAM_WORKSPACE: dependencies.rosinstall
+          # BEFORE_BUILD_TARGET_WORKSPACE: 'apt update -q && python3 -m pip install ****'
+          CLANG_TIDY_ARGS: '--extra-arg=-std=c++17'
+          CLANG_TIDY: pedantic
 
   black_check:
     runs-on: ubuntu-latest
@@ -43,42 +43,40 @@ jobs:
           ROS_DISTRO: humble # Replace humble for your chosen distro.
           BLACK_CHECK: true
 
-  # pylint_check:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: checkout
-  #       uses: actions/checkout@v2
-  #     - name: run industrial_ci
-  #       uses: 'ros-industrial/industrial_ci@master'
-  #       env:
-  #         ROS_DISTRO: humble # Replace humble for your chosen distro.
-  #         # UPSTREAM_WORKSPACE: dependencies.rosinstall
-  #         # BEFORE_BUILD_TARGET_WORKSPACE: 'apt update -q && python3 -m pip install ****'
-  #         PYLINT_ARGS: '--errors-only'
-  #         PYLINT_CHECK: true
+  pylint_check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: run industrial_ci
+        uses: 'ros-industrial/industrial_ci@master'
+        env:
+          ROS_DISTRO: humble # Replace humble for your chosen distro.
+          # UPSTREAM_WORKSPACE: dependencies.rosinstall
+          # BEFORE_BUILD_TARGET_WORKSPACE: 'apt update -q && python3 -m pip install ****'
+          PYLINT_ARGS: '--errors-only'
+          PYLINT_CHECK: true
 
-  # build_check:
-  #   runs-on: ubuntu-latest
-  #   continue-on-error: true
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       env:
-  #         - ROS_DISTRO: humble # Replace humble for your chosen distro.
-  #           ROS_REPO: main
-  #           # UPSTREAM_WORKSPACE: dependencies.rosinstall
-  #           # BEFORE_BUILD_TARGET_WORKSPACE: 'apt update -q && python3 -m pip install ****'
-  #           IMMEDIATE_TEST_OUTPUT: true
-  #         - ROS_DISTRO: humble # Replace humble for your chosen distro.
-  #           ROS_REPO: testing
-  #           # UPSTREAM_WORKSPACE: dependencies.rosinstall
-  #           # BEFORE_BUILD_TARGET_WORKSPACE: 'apt update -q && python3 -m pip install ****'
-  #           IMMEDIATE_TEST_OUTPUT: true
-
-  #   steps:
-  #     - name: checkout
-  #       uses: actions/checkout@v2
-  #     - name: run industrial_ci
-  #       uses: 'ros-industrial/industrial_ci@master'
-  #       env: ${{matrix.env}}
-  
+  build_check:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        env:
+          - ROS_DISTRO: humble # Replace humble for your chosen distro.
+            ROS_REPO: main
+            # UPSTREAM_WORKSPACE: dependencies.rosinstall
+            # BEFORE_BUILD_TARGET_WORKSPACE: 'apt update -q && python3 -m pip install ****'
+            IMMEDIATE_TEST_OUTPUT: true
+          - ROS_DISTRO: humble # Replace humble for your chosen distro.
+            ROS_REPO: testing
+            # UPSTREAM_WORKSPACE: dependencies.rosinstall
+            # BEFORE_BUILD_TARGET_WORKSPACE: 'apt update -q && python3 -m pip install ****'
+            IMMEDIATE_TEST_OUTPUT: true
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: run industrial_ci
+        uses: 'ros-industrial/industrial_ci@master'
+        env: ${{matrix.env}}

--- a/rviz2_plugins/CMakeLists.txt
+++ b/rviz2_plugins/CMakeLists.txt
@@ -53,13 +53,6 @@ install(FILES plugin_description.xml
   DESTINATION share/${PROJECT_NAME}
 )
 
-if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  set(ament_cmake_copyright_FOUND TRUE)
-  set(ament_cmake_cpplint_FOUND TRUE)
-  ament_lint_auto_find_test_dependencies()
-endif()
-
 
 ament_export_libraries(${PROJECT_NAME})
 

--- a/rviz2_plugins/include/rviz2_plugins/state_trigger_panel.h
+++ b/rviz2_plugins/include/rviz2_plugins/state_trigger_panel.h
@@ -27,10 +27,10 @@ class StateTriggerPanel : public rviz_common::Panel
   Q_OBJECT
 public:
   StateTriggerPanel(QWidget* parent = nullptr);
-  virtual ~StateTriggerPanel();
+  ~StateTriggerPanel() override;
 
-  virtual void load(const rviz_common::Config& config);
-  virtual void save(rviz_common::Config config) const;
+  void load(const rviz_common::Config& config) override;
+  void save(rviz_common::Config config) const override;
 
 public Q_SLOTS:
   void pushStartNavigation();

--- a/rviz2_plugins/package.xml
+++ b/rviz2_plugins/package.xml
@@ -18,9 +18,6 @@
   <depend>libqt5-core</depend>
   <depend>libqt5-widgets</depend>
 
-  <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_lint_common</test_depend>
-
   <export>
     <rviz plugin="${prefix}/plugin_description.xml"/>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
## PR Type
<!--
Please select the type of changes you're introducing to the codebase:
-->
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Overview
- Industrial CIのclang_tidy_check、pylint_check、build_checkを有効化します。
<!--
Brief summary of the changes made in this PR.
-->

## Detail
- clang_tidy_check、pylint_check、build_checkのコメントアウトを削除。
- clang-tidyからの修正提案の適用。
- pylint実行前に依存関係の解決。
<!--
In-depth description of the changes, especially if the changes are significant or complex.
-->

## Test
- [x] 全てのCI通過の確認。
<!--
what was done to ensure it works.
Example:
- [ ] I have tested this change with gazebo
- [ ] I have tested this change with rosbag
-->

## Attention
- ROS 2のBUILD_TESTINGはIndustrial CIの実行の邪魔になるので削除しています。
<!--
Any particular attention or caution the reviewers should have regarding the PR.
-->
