### PR TITLE
Add functioin to start from middle waypoint

### DIFF
--- a/waypoint_navigation/include/waypoint_navigation/waypoint_nav.h
+++ b/waypoint_navigation/include/waypoint_navigation/waypoint_nav.h
@@ -5,6 +5,7 @@
 #include <std_msgs/msg/u_int16.hpp>
 #include <geometry_msgs/msg/pose_array.hpp>
 #include <geometry_msgs/msg/twist.hpp>
+#include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <nav2_msgs/action/navigate_to_pose.hpp>
 #include <nav2_msgs/srv/clear_costmap_around_robot.hpp>
@@ -30,6 +31,7 @@ public:
 private:
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr start_server_, stop_server_, resume_server_;
   rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_sub_;
+  rclcpp::Subscription<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr init_pose_sub_;
   rclcpp::Publisher<geometry_msgs::msg::PoseArray>::SharedPtr wp_vis_pub_;
   rclcpp::Publisher<std_msgs::msg::UInt16>::SharedPtr wp_num_pub_;
   rclcpp::TimerBase::SharedPtr timer_;
@@ -46,7 +48,7 @@ private:
   uint16_t wp_num_;
   double last_move_time_, start_nav_time_;
   float target_yaw_, min_dist_err_, min_yaw_err_;
-  bool has_activate_;
+  bool has_activate_, start_from_mid_;
 
   // Service callback functions
   bool startNavCallback(const std::shared_ptr<std_srvs::srv::Trigger::Request>& request,
@@ -57,6 +59,7 @@ private:
                          std::shared_ptr<std_srvs::srv::Trigger::Response> response);
   // Topic callback functions
   void cmdVelCallback(const geometry_msgs::msg::Twist::SharedPtr msg);
+  void initPoseCallback(const geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr msg);
   // Nav2 action callback functions
   void responseCallback(const GoalHandleNavToPose::SharedPtr& future);
   void feedbackCallback(GoalHandleNavToPose::SharedPtr p, const std::shared_ptr<const NavToPose::Feedback>& feedback);
@@ -69,5 +72,6 @@ private:
   void clearCostmap();
   void sendGoal(const geometry_msgs::msg::Pose& goal_pose);
   bool onNavPoint(const geometry_msgs::msg::Pose& goal_pose);
+  double getYaw(const geometry_msgs::msg::Quaternion& orientation);
   void execLoop();
 };

--- a/waypoint_navigation/launch/waypoint_nav.launch.xml
+++ b/waypoint_navigation/launch/waypoint_nav.launch.xml
@@ -7,6 +7,7 @@
     <arg name="robot_frame"     default="base_footprint"/>
     <arg name="min_dist_err"    default="0.3"/>
     <arg name="min_yaw_err"     default="0.3"/>
+    <arg name="from_middle"     default="false"/>
     <arg name="tandem_scan"     default="merged_scan"/>
     <arg name="use_angle"       default="20.0"/>
     <arg name="danger_dist"     default="2.0"/>
@@ -15,12 +16,13 @@
 
     <!-- Node for waypoints navigation -->
     <node pkg="waypoint_navigation" exec="waypoint_nav" output="screen" launch-prefix="xterm -e">
-        <param name="waypoints_file"  value="$(var waypoints_file)"/>
-        <param name="world_frame"     value="$(var world_frame)"/>
-        <param name="robot_frame"     value="$(var robot_frame)"/>
-        <param name="min_dist_err"    value="$(var min_dist_err)"/>
-        <param name="min_yaw_err"     value="$(var min_yaw_err)"/>
-        <param name="use_sim_time"    value="$(var use_sim_time)"/>
+        <param name="waypoints_file"    value="$(var waypoints_file)"/>
+        <param name="world_frame"       value="$(var world_frame)"/>
+        <param name="robot_frame"       value="$(var robot_frame)"/>
+        <param name="min_dist_err"      value="$(var min_dist_err)"/>
+        <param name="min_yaw_err"       value="$(var min_yaw_err)"/>
+        <param name="start_from_middle" value="$(var from_middle)"/>
+        <param name="use_sim_time"      value="$(var use_sim_time)"/>
     </node>
 
     <!-- Node for traffic congestion management -->

--- a/waypoint_navigation/src/waypoint_nav.cpp
+++ b/waypoint_navigation/src/waypoint_nav.cpp
@@ -89,7 +89,6 @@ bool WaypointsNavigation::startNavCallback(const std::shared_ptr<std_srvs::srv::
       conv_x = (compare_wp->x - init_x) * cos(-init_yaw) - (compare_wp->y - init_y) * sin(-init_yaw);
       if ((dist_wp < min_dist_wp) && (std::abs(dir_wp - init_yaw) < yaw_thresh) && (conv_x > 0))
       {
-        RCLCPP_INFO(this->get_logger(), "%ld, %f, %f, %f", i, dist_wp, std::abs(dir_wp - init_yaw), conv_x);
         min_dist_wp = dist_wp;
         current_wp_ = pose_array_.poses.begin() + i;
         wp_num_ = i + 1;

--- a/waypoint_navigation/src/waypoint_nav.cpp
+++ b/waypoint_navigation/src/waypoint_nav.cpp
@@ -8,11 +8,13 @@ WaypointsNavigation::WaypointsNavigation() : Node("waypoint_nav"), nav_time_(0),
   this->declare_parameter<std::string>("robot_frame", "base_footprint");
   this->declare_parameter<float>("min_dist_err", 0.3);
   this->declare_parameter<float>("min_yaw_err", 0.3);
+  this->declare_parameter<bool>("start_from_middle", false);
 
   this->get_parameter("world_frame", world_frame_);
   this->get_parameter("robot_frame", robot_frame_);
   this->get_parameter("min_dist_err", min_dist_err_);
   this->get_parameter("min_yaw_err", min_yaw_err_);
+  this->get_parameter("start_from_middle", start_from_mid_);
 
   // Load YAML file
   std::string waypoints_file = "";
@@ -30,6 +32,8 @@ WaypointsNavigation::WaypointsNavigation() : Node("waypoint_nav"), nav_time_(0),
   wp_num_pub_ = this->create_publisher<std_msgs::msg::UInt16>("waypoint_num", 10);
   cmd_vel_sub_ = this->create_subscription<geometry_msgs::msg::Twist>(
       "cmd_vel", 1, std::bind(&WaypointsNavigation::cmdVelCallback, this, _1));
+  init_pose_sub_ = this->create_subscription<geometry_msgs::msg::PoseWithCovarianceStamped>(
+      "initialpose", 1, std::bind(&WaypointsNavigation::initPoseCallback, this, _1));
 
   // Service
   start_server_ = create_service<std_srvs::srv::Trigger>(
@@ -62,9 +66,48 @@ bool WaypointsNavigation::startNavCallback(const std::shared_ptr<std_srvs::srv::
     response->success = false;
     return false;
   }
-  RCLCPP_INFO(this->get_logger(), "Navigation is started now");
   wp_num_ = 1;
   current_wp_ = pose_array_.poses.begin();
+
+  if (start_from_mid_)
+  {
+    // Find a waypoint that is closest to robot and match the direction
+    auto compare_wp = waypoint_list_.begin();
+    double init_x = current_pose_.position.x;
+    double init_y = current_pose_.position.y;
+    double init_yaw = getYaw(current_pose_.orientation);
+    double min_dist_wp = DBL_MAX;
+    double yaw_thresh = M_PI / 2;
+    double pre_wp_x = 0, pre_wp_y = 0;
+    double dist_wp, dir_wp, conv_x;
+    size_t num_wp = waypoint_list_.size();
+    size_t i = 0;
+    for (i = 0; i < num_wp; i++)
+    {
+      dist_wp = std::sqrt(std::pow(compare_wp->x - init_x, 2) + std::pow(compare_wp->y - init_y, 2));
+      dir_wp = std::atan2(compare_wp->y - pre_wp_y, compare_wp->x - pre_wp_x);
+      conv_x = (compare_wp->x - init_x) * cos(-init_yaw) - (compare_wp->y - init_y) * sin(-init_yaw);
+      if ((dist_wp < min_dist_wp) && (std::abs(dir_wp - init_yaw) < yaw_thresh) && (conv_x > 0))
+      {
+        RCLCPP_INFO(this->get_logger(), "%ld, %f, %f, %f", i, dist_wp, std::abs(dir_wp - init_yaw), conv_x);
+        min_dist_wp = dist_wp;
+        current_wp_ = pose_array_.poses.begin() + i;
+        wp_num_ = i + 1;
+      }
+      pre_wp_x = compare_wp->x;
+      pre_wp_y = compare_wp->y;
+      compare_wp++;
+    }
+    if (min_dist_wp == DBL_MAX)
+    {
+      RCLCPP_WARN(this->get_logger(), "Could not find the closest appropriate waypoint");
+      response->success = false;
+      return false;
+    }
+  }
+
+  // Send first goal
+  RCLCPP_INFO(this->get_logger(), "Navigation is started now");
   sendGoal(*current_wp_);
   response->success = true;
   has_activate_ = true;
@@ -116,6 +159,14 @@ void WaypointsNavigation::cmdVelCallback(const geometry_msgs::msg::Twist::Shared
   }
   else
     last_move_time_ = now().seconds();
+}
+
+void WaypointsNavigation::initPoseCallback(const geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr msg)
+{
+  if (!start_from_mid_)
+    RCLCPP_WARN(this->get_logger(), "Are you sure the parameter \"start_from_middle\" is false?");
+  RCLCPP_INFO_STREAM(this->get_logger(), "Initial pose is set");
+  current_pose_ = msg->pose.pose;
 }
 
 void WaypointsNavigation::responseCallback(const GoalHandleNavToPose::SharedPtr& future)
@@ -291,16 +342,21 @@ bool WaypointsNavigation::onNavPoint(const geometry_msgs::msg::Pose& goal_pose)
   float dist_err = waypoint_list_[wp_num_ - 1].rad;
   if (waypoint_list_[wp_num_ - 1].stop)
   {
-    tf2::Quaternion tf2_quat;
-    tf2::fromMsg(robot_pose.orientation, tf2_quat);
-    tf2::Matrix3x3 m(tf2_quat);
-    double r, p, robot_yaw;
-    m.getRPY(r, p, robot_yaw);
-    double yaw_diff = std::abs(target_yaw_ - robot_yaw);
+    double yaw_diff = std::abs(target_yaw_ - getYaw(robot_pose.orientation));
     return ((dist < min_dist_err_) && (yaw_diff < min_yaw_err_)) ||
            (nav_status_ == rclcpp_action::ResultCode::SUCCEEDED);
   }
   return dist < dist_err;
+}
+
+double WaypointsNavigation::getYaw(const geometry_msgs::msg::Quaternion& orientation)
+{
+  tf2::Quaternion tf2_quat;
+  tf2::fromMsg(orientation, tf2_quat);
+  tf2::Matrix3x3 m(tf2_quat);
+  double roll, pitch, yaw;
+  m.getRPY(roll, pitch, yaw);
+  return yaw;
 }
 
 void WaypointsNavigation::execLoop()


### PR DESCRIPTION
## PR Type
<!--
Please select the type of changes you're introducing to the codebase:
-->
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Overview
- 途中のウェイポイントからナビゲーションを始める機能を waypoint_nav に追加
<!--
Brief summary of the changes made in this PR.
-->

## Detail
- ロボットの初期位置から自動で途中のウェイポイントを選択し、ナビゲーションを開始する機能を追加しました。
- start_from_mid パラメータを true にすることで有効化できます。
- 上記の"ロボットの初期位置"とは、rviz の 2D Pose Estimate により指定したロボットの姿勢のことを指します。指定しなかった場合、原点にいるものとみなされます。
- 選択されるウェイポイントの基準は以下の3つです。
  1. ロボットからみて正面にある
  2. 1つ前のウェイポイントからみた向きとロボットの向きとの差が pi/2 未満である
  3. 上記を満たすもののうち最もロボットに近い
- launch ファイルによる有効化については、https://github.com/KBKN-Autonomous-Robotics-Lab/orange_ros2/pull/71 こちらの PR に記載していますので、ご確認ください。
<!--
In-depth description of the changes, especially if the changes are significant or complex.
-->

## Test
- [x] シミュレーションでの検証
- [ ] 実環境での検証 
<!--
what was done to ensure it works.
Example:
- [ ] I have tested this change with gazebo
- [ ] I have tested this change with rosbag
-->

## Attention
- 
<!--
Any particular attention or caution the reviewers should have regarding the PR.
-->
