### PR TITLE
fix_no_movement_time

### DIFF
--- a/waypoint_navigation/include/waypoint_navigation/waypoint_nav.h
+++ b/waypoint_navigation/include/waypoint_navigation/waypoint_nav.h
@@ -48,6 +48,7 @@ private:
   uint16_t wp_num_;
   double last_move_time_, start_nav_time_;
   float target_yaw_, min_dist_err_, min_yaw_err_;
+  float timeout_restart_nav_;
   bool has_activate_, start_from_mid_;
 
   // Service callback functions

--- a/waypoint_navigation/launch/waypoint_nav.launch.xml
+++ b/waypoint_navigation/launch/waypoint_nav.launch.xml
@@ -1,40 +1,38 @@
 <?xml version="1.0"?>
 <launch>
-    <!-- Arguments -->
-    <arg name="use_sim_time"    default="false"/>
-    <arg name="waypoints_file"  default="$(find-pkg-share waypoint_navigation)/waypoints_cfg/waypoints.yaml"/>
-    <arg name="world_frame"     default="map"/>
-    <arg name="robot_frame"     default="base_footprint"/>
-    <arg name="min_dist_err"    default="0.3"/>
-    <arg name="min_yaw_err"     default="0.3"/>
-    <arg name="timeout_restart_nav" default="5.0"/>
-    <arg name="from_middle"     default="false"/>
-    <arg name="tandem_scan"     default="merged_scan"/>
-    <arg name="use_angle"       default="20.0"/>
-    <arg name="danger_dist"     default="2.0"/>
-    <arg name="costmaps_file"   default="$(find-pkg-share waypoint_navigation)/config/switch_costmaps.yaml"/>
+  <!-- Arguments -->
+  <arg name="use_sim_time" default="false"/>
+  <arg name="waypoints_file" default="$(find-pkg-share waypoint_navigation)/waypoints_cfg/waypoints.yaml"/>
+  <arg name="world_frame" default="map"/>
+  <arg name="robot_frame" default="base_footprint"/>
+  <arg name="min_dist_err" default="0.3"/>
+  <arg name="min_yaw_err" default="0.3"/>
+  <arg name="timeout_restart_nav" default="5.0"/>
+  <arg name="from_middle" default="false"/>
+  <arg name="tandem_scan" default="merged_scan"/>
+  <arg name="use_angle" default="20.0"/>
+  <arg name="danger_dist" default="2.0"/>
+  <arg name="costmaps_file" default="$(find-pkg-share waypoint_navigation)/config/switch_costmaps.yaml"/>
 
+  <!-- Node for waypoints navigation -->
+  <node pkg="waypoint_navigation" exec="waypoint_nav" output="screen" launch-prefix="xterm -e">
+    <param name="waypoints_file" value="$(var waypoints_file)"/>
+    <param name="world_frame" value="$(var world_frame)"/>
+    <param name="robot_frame" value="$(var robot_frame)"/>
+    <param name="min_dist_err" value="$(var min_dist_err)"/>
+    <param name="min_yaw_err" value="$(var min_yaw_err)"/>
+    <param name="timeout_restart_nav" value="$(var timeout_restart_nav)"/>
+    <param name="start_from_middle" value="$(var from_middle)"/>
+    <param name="use_sim_time" value="$(var use_sim_time)"/>
+  </node>
 
-    <!-- Node for waypoints navigation -->
-    <node pkg="waypoint_navigation" exec="waypoint_nav" output="screen" launch-prefix="xterm -e">
-        <param name="waypoints_file"    value="$(var waypoints_file)"/>
-        <param name="world_frame"       value="$(var world_frame)"/>
-        <param name="robot_frame"       value="$(var robot_frame)"/>
-        <param name="min_dist_err"      value="$(var min_dist_err)"/>
-        <param name="min_yaw_err"       value="$(var min_yaw_err)"/>
-        <param name="timeout_restart_nav" value="$(var timeout_restart_nav)"/>
-        <param name="start_from_middle" value="$(var from_middle)"/>
-        <param name="use_sim_time"      value="$(var use_sim_time)"/>
-    </node>
-
-    <!-- Node for traffic congestion management -->
-    <node pkg="waypoint_navigation" exec="tandem_run_manager.py" output="screen">
-        <param name="waypoints_file"           value="$(var waypoints_file)"/>
-        <param name="use_angle"                value="$(var use_angle)"/>
-        <param name="danger_dist"              value="$(var danger_dist)"/>
-        <param name="use_sim_time"             value="$(var use_sim_time)"/>
-        <param from="$(var costmaps_file)"/>
-
-        <remap from="scan" to="$(var tandem_scan)"/>
-    </node>
+  <!-- Node for traffic congestion management -->
+  <node pkg="waypoint_navigation" exec="tandem_run_manager.py" output="screen">
+    <param name="waypoints_file" value="$(var waypoints_file)"/>
+    <param name="use_angle" value="$(var use_angle)"/>
+    <param name="danger_dist" value="$(var danger_dist)"/>
+    <param name="use_sim_time" value="$(var use_sim_time)"/>
+    <param from="$(var costmaps_file)"/>
+    <remap from="scan" to="$(var tandem_scan)"/>
+  </node>
 </launch>

--- a/waypoint_navigation/launch/waypoint_nav.launch.xml
+++ b/waypoint_navigation/launch/waypoint_nav.launch.xml
@@ -7,6 +7,7 @@
     <arg name="robot_frame"     default="base_footprint"/>
     <arg name="min_dist_err"    default="0.3"/>
     <arg name="min_yaw_err"     default="0.3"/>
+    <arg name="timeout_restart_nav" default="5.0"/>
     <arg name="from_middle"     default="false"/>
     <arg name="tandem_scan"     default="merged_scan"/>
     <arg name="use_angle"       default="20.0"/>
@@ -21,6 +22,7 @@
         <param name="robot_frame"       value="$(var robot_frame)"/>
         <param name="min_dist_err"      value="$(var min_dist_err)"/>
         <param name="min_yaw_err"       value="$(var min_yaw_err)"/>
+        <param name="timeout_restart_nav" value="$(var timeout_restart_nav)"/>
         <param name="start_from_middle" value="$(var from_middle)"/>
         <param name="use_sim_time"      value="$(var use_sim_time)"/>
     </node>

--- a/waypoint_navigation/src/waypoint_nav.cpp
+++ b/waypoint_navigation/src/waypoint_nav.cpp
@@ -8,7 +8,7 @@ WaypointsNavigation::WaypointsNavigation() : Node("waypoint_nav"), nav_time_(0),
   this->declare_parameter<std::string>("robot_frame", "base_footprint");
   this->declare_parameter<float>("min_dist_err", 0.3);
   this->declare_parameter<float>("min_yaw_err", 0.3);
-  this->declare_parameter<float>("timeout_restart_nav", 5);
+  this->declare_parameter<float>("timeout_restart_nav", 5.0);
   this->declare_parameter<bool>("start_from_middle", false);
 
   this->get_parameter("world_frame", world_frame_);

--- a/waypoint_navigation/src/waypoint_nav.cpp
+++ b/waypoint_navigation/src/waypoint_nav.cpp
@@ -8,12 +8,14 @@ WaypointsNavigation::WaypointsNavigation() : Node("waypoint_nav"), nav_time_(0),
   this->declare_parameter<std::string>("robot_frame", "base_footprint");
   this->declare_parameter<float>("min_dist_err", 0.3);
   this->declare_parameter<float>("min_yaw_err", 0.3);
+  this->declare_parameter<float>("timeout_restart_nav", 5);
   this->declare_parameter<bool>("start_from_middle", false);
 
   this->get_parameter("world_frame", world_frame_);
   this->get_parameter("robot_frame", robot_frame_);
   this->get_parameter("min_dist_err", min_dist_err_);
   this->get_parameter("min_yaw_err", min_yaw_err_);
+  this->get_parameter("timeout_restart_nav", timeout_restart_nav_);
   this->get_parameter("start_from_middle", start_from_mid_);
 
   // Load YAML file
@@ -374,7 +376,7 @@ void WaypointsNavigation::execLoop()
 
   // If no movement for certain period of time after sending goal
   double t = now().seconds();
-  if ((t - start_nav_time_ > 5) && (t - last_move_time_ > 5))
+  if ((t - start_nav_time_ > timeout_restart_nav_) && (t - last_move_time_ > timeout_restart_nav_))
   {
     RCLCPP_WARN(this->get_logger(), "Resend current goal");
     clearCostmap();

--- a/waypoint_navigation/src/waypoint_nav.cpp
+++ b/waypoint_navigation/src/waypoint_nav.cpp
@@ -374,7 +374,7 @@ void WaypointsNavigation::execLoop()
 
   // If no movement for certain period of time after sending goal
   double t = now().seconds();
-  if ((t - start_nav_time_ > 10) && (t - last_move_time_ > 10))
+  if ((t - start_nav_time_ > 5) && (t - last_move_time_ > 5))
   {
     RCLCPP_WARN(this->get_logger(), "Resend current goal");
     clearCostmap();


### PR DESCRIPTION
## PR Type
<!--
Please select the type of changes you're introducing to the codebase:
-->
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Overview
- Pathが生成されているのにロボットが動かない時の再考時間の変更. 
<!--
Brief summary of the changes made in this PR.
-->

## Detail
- Navigation2でウェイポイントナビゲーションをしている際に, Pathが出ているのにも関わらずロボットが動かない問題があります. (これは現在進行形です, ロボットの走行時間や実験時間が長いほど多く現れ, コンテナやPCの再起動をすると回復する傾向にあります. )
- その対策として, ロボットが動いていない時に新しいPathを生成するようにしています. 
- この動作を今までは10秒待ってから行っていましたが, 走らせている中で10秒は長いと感じたため " 5秒 " に変更しました. 
<!--
In-depth description of the changes, especially if the changes are significant or complex.
-->

## Test
- [x] つくばで実機を用いて確認済みです. 
<!--
what was done to ensure it works.
Example:
- [ ] I have tested this change with gazebo
- [ ] I have tested this change with rosbag
-->
